### PR TITLE
schedule lazy dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,35 +6,40 @@
 /* Dependencies. */
 var CompositeDisposable = require('atom').CompositeDisposable;
 
+var engine;
 var idleCallbacks = new Set();
 
 /* Subscriptions. */
 var subscriptions = new CompositeDisposable();
 var config = {};
-var engine;
 
 /* Expose. */
 exports.activate = activate;
 exports.deactivate = deactivate;
 exports.provideLinter = linter;
 
-const makeIdleCallback = work => {
-  let callbackId;
+function loadDeps() {
+  if (!engine) {
+    engine = require('unified-engine-atom');
+  }
+}
+
+function makeIdleCallback(work) {
+  var callbackId;
   var callBack = () => {
     idleCallbacks.delete(callbackId);
     work();
   };
   callbackId = window.requestIdleCallback(callBack);
   idleCallbacks.add(callbackId);
-};
+}
 
 function scheduleIdleTasks() {
-  var linterRemarkInstallPeerPackages = () => {
+  function linterRemarkInstallPeerPackages() {
     require('atom-package-deps').install('linter-remark');
-  };
-  const linterRemarkLoadDependencies = () => {
-    engine = require('unified-engine-atom');
-  };
+  }
+
+  var linterRemarkLoadDependencies = loadDeps;
 
   if (!atom.inSpecMode()) {
     makeIdleCallback(linterRemarkInstallPeerPackages);
@@ -59,6 +64,8 @@ function activate() {
 
 /* Deactivation tasks. */
 function deactivate() {
+  idleCallbacks.forEach(callbackID => window.cancelIdleCallback(callbackID));
+  idleCallbacks.clear();
   subscriptions.dispose();
 }
 
@@ -75,6 +82,8 @@ function linter() {
 
 /* One run. */
 function lint(editor) {
+  loadDeps();
+
   return engine({
     processor: require('remark'),
     pluginPrefix: 'remark',


### PR DESCRIPTION
This isn't complete, but it's part way towards quicker load times when using `linter-remark`

I based this off the [`linter-eslint`](https://github.com/AtomLinter/linter-eslint/blob/081a492e02a4969f9033ce7eaa167c0ae8c1fd0b/src/main.js) package

The current changes reduced load time from >250ms to <5ms

There's most likely timing issues around the `engine` not being ready before `lint` is called