### PR TITLE
Use remark-language-server

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ class RemarkLanguageClient extends AutoLanguageClient {
   }
 
   getServerName() {
-    return 'Remark'
+    return 'remark'
   }
 
   startServerProcess() {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const { AutoLanguageClient } = require('atom-languageclient')
-const { install } = require('atom-package-deps')
+const {AutoLanguageClient} = require('atom-languageclient')
+const {install} = require('atom-package-deps')
 
 const pkg = require('./package.json')
 
@@ -19,7 +19,9 @@ class RemarkLanguageClient extends AutoLanguageClient {
   }
 
   startServerProcess() {
-    return super.spawn(require.resolve('.bin/remark-language-server'), ['--stdio'])
+    return super.spawn(require.resolve('.bin/remark-language-server'), [
+      '--stdio'
+    ])
   }
 
   activate() {

--- a/package.json
+++ b/package.json
@@ -27,12 +27,13 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "package-deps": [
+    "atom-ide-code-format",
     "linter"
   ],
   "dependencies": {
+    "atom-languageclient": "^1.0.0",
     "atom-package-deps": "^7.0.0",
-    "remark": "^13.0.0",
-    "unified-engine-atom": "^9.0.0"
+    "remark-language-server": "^1.0.0"
   },
   "devDependencies": {
     "atom-tap-test-runner": "^7.0.0",
@@ -74,38 +75,28 @@
     ]
   },
   "atomTestRunner": "atom-tap-test-runner",
+  "enhancedScopes": [
+    "source.gfm",
+    "source.pfm",
+    "text.md"
+  ],
   "providedServices": {
-    "linter": {
+    "code-format.range": {
       "versions": {
-        "2.0.0": "provideLinter"
+        "0.1.0": "provideCodeFormat"
       }
     }
   },
-  "configSchema": {
-    "detectConfig": {
-      "title": "Config files",
-      "description": "Use `.remarkrc` files and `remarkConfig` in `package.json` files.",
-      "type": "boolean",
-      "default": true
+  "consumedServices": {
+    "console": {
+      "versions": {
+        "0.1.0": "consumeConsole"
+      }
     },
-    "detectIgnore": {
-      "title": "Ignore files",
-      "description": "Use `.remarkignore` files.",
-      "type": "boolean",
-      "default": true
-    },
-    "scopes": {
-      "title": "Scopes",
-      "description": "List of scopes for languages which will be checked (run `Editor: Log Cursor Scope` to determine the scopes for a file).",
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "default": [
-        "source.gfm",
-        "source.pfm",
-        "text.md"
-      ]
+    "linter-indie": {
+      "versions": {
+        "2.0.0": "consumeLinterV2"
+      }
     }
   }
 }


### PR DESCRIPTION
This adds support for:

- Formatting using atom-ide-code-format
- ESM configuration files
- ESM plugins

I don’t use atom myself nor am I familiar with its plugin API. For me this is mostly a proof of concept to show `remark-language-server` works for multiple editors.

Closes #14